### PR TITLE
Add docker analysis environment

### DIFF
--- a/.jupyter/custom/custum.css
+++ b/.jupyter/custom/custum.css
@@ -1,0 +1,9 @@
+div.rendered_html code {
+    font-family: monospace, monospace;
+    font-size: 11pt;
+    padding-top: 3px;
+    padding-left: 2px;
+    color: #c7254e;
+    background-color: #f9f2f4;
+    border-radius: 2px;
+}

--- a/.jupyter/custom/custum.css
+++ b/.jupyter/custom/custum.css
@@ -1,6 +1,6 @@
 div.rendered_html code {
     font-family: monospace, monospace;
-    font-size: 11pt;
+    font-size: 90%;
     padding-top: 3px;
     padding-left: 2px;
     color: #c7254e;

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,5 @@ RUN pip install RISE \
     && jupyter-nbextension install rise --py --sys-prefix \
     && jupyter-nbextension enable rise --py --sys-prefix \
     && conda install -c rdkit rdkit
+
+COPY .jupyter/custom/custum.css /home/jovyan/.jupyter/custom/custom.css

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM jupyter/scipy-notebook:latest
+
+RUN pip install RISE \
+    && jupyter-nbextension install rise --py --sys-prefix \
+    && jupyter-nbextension enable rise --py --sys-prefix \
+    && conda install -c rdkit rdkit


### PR DESCRIPTION
## 実習環境の構築
- ベース環境：[jupyter/scipy-notebook - Docker Hub](https://hub.docker.com/r/jupyter/scipy-notebook/)
- 追加ライブラリ類：
    - RDKit from conda（https://anaconda.org/rdkit/rdkit）
    - RISE [damianavila/RISE: RISE: "Live" Reveal.js Jupyter/IPython Slideshow Extension](https://github.com/damianavila/RISE)

## 使用方法
最終的にはdocker hubで公開するのでビルドはローカルでしない想定ですが、開発用には以下の手順で起動、講義用の ipynb を編集、実行が可能です。

1. `Dockerfile` のある位置に移動
```
$ pwd
/Users/kubor/src/chemo-wakate/tutorial-6th
```

2. `docker build` でビルド  
ここではコンテナの名前を `chemo_tutorial` にしています
```
$ docker build -t chemo_tutorial ./
```

3. `chemo-wakate/tutorial-6th` をマウントして `jupyter notebook` を起動  
`~/chemo-wakate/tutorial-6th/` の部分は、各自でリポジトリを `clone` した位置を指定してください。
```
$ docker run --rm -it -p 8888:8888 -v ~/chemo-wakate/tutorial-6th/:/home/jovyan/chemo -t chemo_tutorial
```

起動後ブラウザで確認すると以下のようになっているはずです  
`work` はもとから用意されている空のディレクトリです
<img width="308" alt="2017-09-07 15 27 18" src="https://user-images.githubusercontent.com/7918702/30149045-13e9a400-93e1-11e7-9667-b51cbabf42b9.png">

## ディレクトリ構造について
`/chemo` のルートディレクトリは以下の通り、 `chemo-wakate/tutorial-6th` そのままとなります。
<img width="277" alt="2017-09-07 15 33 30" src="https://user-images.githubusercontent.com/7918702/30149282-04c37acc-93e2-11e7-8d9b-fff766b9bc37.png">

`beginner/` 直下には、講義ごとのノートブックを格納しています。
<img width="324" alt="2017-09-07 15 33 39" src="https://user-images.githubusercontent.com/7918702/30149341-3e34365c-93e2-11e7-99de-1096d258a9a7.png">

RISEが入っているので右上のボタンを押すとスライドモードを使用することができます。
<img width="664" alt="2017-09-07 15 33 46" src="https://user-images.githubusercontent.com/7918702/30149364-4faf6d16-93e2-11e7-9dbd-c95f208f33b6.png">

## ご相談
特に以下の2点についてご確認ください。
- ディレクトリ構造
- 追加ライブラリ

@chemo-wakate/tutorial 